### PR TITLE
Plugin split

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,11 @@ outputString = markdown.markdown(
 
 Currently supported options are listed below:
 
-* `figure_caption_prefix` (default: `"Figure"`):
+* `caption_prefix` (default: `"Figure"`):
 
     The text to show at the front of the caption. A final non-breaking space
-    is inserted between the content of `table_caption_prefix` and the actual figure
+    is inserted between the content of `caption_prefix` and the actual figure
     number.
-
-* `table_caption_prefix` (default: `"Table"`):
-
-    Same as `figure_caption_prefix`, but for tables.
-
-* `listing_caption_prefix` (default: `"Listing"`):
-  
-    Same as `figure_caption_prefix`, but for listings.
 
 * `numbering` (default: `True`):
 

--- a/caption/__init__.py
+++ b/caption/__init__.py
@@ -6,5 +6,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from .caption import makeExtension, CaptionExtension
+from .image_caption import ImageCaptionExtension
 
 __all__ = ['makeExtension', 'CaptionExtension']

--- a/caption/__init__.py
+++ b/caption/__init__.py
@@ -1,6 +1,7 @@
 # caption: Manage markdown captions
 #
-# Copyright (c) 2020 flywire
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/caption/__init__.py
+++ b/caption/__init__.py
@@ -7,5 +7,6 @@
 
 from .image_caption import ImageCaptionExtension
 from .table_caption import TableCaptionExtension
+from .caption import CaptionExtension
 
-__all__ = ['ImageCaptionExtension', 'TableCaptionExtension']
+__all__ = ['ImageCaptionExtension', 'TableCaptionExtension', 'CaptionExtension']

--- a/caption/__init__.py
+++ b/caption/__init__.py
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-from .caption import makeExtension, CaptionExtension
 from .image_caption import ImageCaptionExtension
+from .table_caption import TableCaptionExtension
 
-__all__ = ['makeExtension', 'CaptionExtension']
+__all__ = ['ImageCaptionExtension', 'TableCaptionExtension']

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -113,38 +113,6 @@ class ListingCaptionTreeProcessor(CaptionTreeprocessor):
         return par.text[9:]
 
 
-class FigureCaptionTreeProcessor(CaptionTreeprocessor):
-    name = "figure"
-    content_tag = "figure"
-
-    def matches(self, par):
-        self._a = None
-        self._img = par.find("./img")
-        if self._img is None:
-            self._a = par.find("./a")
-            if self._a is None:
-                return False
-            self._img = self._a.find("./img")
-        return self._img is not None
-
-    def get_title(self, par):
-        return self._img.get("title")
-
-    def build_content_element(self, par):
-        super(FigureCaptionTreeProcessor, self).build_content_element(par)
-        if self._a is not None:
-            self._a.tail = "\n"
-            par.append(self._a)
-        else:
-            self._img.tail = self._img.tail or "" + "\n"
-            par.append(self._img)
-
-    def build_caption_element(self, par, title):
-        super(FigureCaptionTreeProcessor, self).build_caption_element(par, title)
-        if self.link_process == "strip_title" and title:
-            del self._img.attrib["title"]
-
-
 class TableCaptionTreeProcessor(CaptionTreeprocessor):
     name = "table"
     content_tag = "div class=table"
@@ -195,19 +163,6 @@ class CaptionExtension(Extension):
         content_class = self.getConfig("content_class")
         link_process = self.getConfig("link_process")
 
-        md.treeprocessors.register(
-            FigureCaptionTreeProcessor(
-                md,
-                caption_prefix=self.getConfig("figure_caption_prefix"),
-                numbering=numbering,
-                caption_prefix_class=caption_prefix_class,
-                caption_class=caption_class,
-                content_class=content_class,
-                link_process=link_process or "strip_title",
-            ),
-            "figurecaptiontreeprocessor",
-            8,
-        )
         md.treeprocessors.register(
             TableCaptionTreeProcessor(
                 md,

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -4,7 +4,8 @@ caption - Manage markdown captions
 Applying style and auto-numbering to Python-Markdown content.
 
 https://github.com/flywire/caption
-Copyright (c) 2020 flywire
+Copyright (c) 2020-2023 flywire
+Copyright (c) 2023 sanzoghenzo
 forked from yafg - https://git.sr.ht/~ferruck/yafg
 Copyright (c) 2019-2020 Philipp Trommler
 

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -143,6 +143,7 @@ class CaptionExtension(Extension):
             "caption_class": ["", "CSS class to add to the caption element."],
             "content_class": ["", "CSS class to add to the content element."],
             "link_process": ["", "Some content types support linked processes."],
+            "caption_top": [False, "Put the caption at the top of the content."],
         }
         super(CaptionExtension, self).__init__(**kwargs)
 

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -1,0 +1,109 @@
+"""
+caption - Manage markdown captions
+
+Applying style and auto-numbering to Python-Markdown content.
+
+https://github.com/flywire/caption
+Copyright (c) 2020-2023 flywire
+Copyright (c) 2023 sanzoghenzo
+forked from yafg - https://git.sr.ht/~ferruck/yafg
+Copyright (c) 2019-2020 Philipp Trommler
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+from markdown import Extension
+
+from caption.caption import CaptionTreeprocessor
+
+
+class ImageCaptionTreeProcessor(CaptionTreeprocessor):
+    name = "figure"
+    content_tag = "figure"
+
+    def __init__(
+        self,
+        md=None,
+        caption_prefix="",
+        numbering=True,
+        caption_prefix_class=None,
+        caption_class=None,
+        content_class=None,
+        strip_title=True,
+    ):
+        super(ImageCaptionTreeProcessor, self).__init__(
+            md,
+            caption_prefix,
+            numbering,
+            caption_prefix_class,
+            caption_class,
+            content_class
+        )
+        self.strip_title = strip_title
+
+    def matches(self, par):
+        self._a = None
+        self._img = par.find("./img")
+        if self._img is None:
+            self._a = par.find("./a")
+            if self._a is None:
+                return False
+            self._img = self._a.find("./img")
+        return self._img is not None
+
+    def get_title(self, par):
+        return self._img.get("title")
+
+    def build_content_element(self, par):
+        super(ImageCaptionTreeProcessor, self).build_content_element(par)
+        if self._a is not None:
+            self._a.tail = "\n"
+            par.append(self._a)
+        else:
+            self._img.tail = self._img.tail or "" + "\n"
+            par.append(self._img)
+
+    def build_caption_element(self, par, title):
+        super(ImageCaptionTreeProcessor, self).build_caption_element(par, title)
+        if self.strip_title and title:
+            del self._img.attrib["title"]
+
+
+class ImageCaptionExtension(Extension):
+    # caption Extension
+
+    def __init__(self, **kwargs):
+        # Setup configs
+        self.config = {
+            "caption_prefix": [
+                "Figure",
+                "The text to show in front of the image caption.",
+            ],
+            "numbering": [True, "Add the caption number to the prefix."],
+            "caption_prefix_class": [
+                "",
+                "CSS class to add to the caption prefix <span /> element.",
+            ],
+            "caption_class": ["", "CSS class to add to the caption element."],
+            "content_class": ["", "CSS class to add to the content element."],
+            "strip_title": [True, "Remove the title from the img tag."],
+        }
+        super(ImageCaptionExtension, self).__init__(**kwargs)
+
+    def extendMarkdown(self, md):
+        md.treeprocessors.register(
+            ImageCaptionTreeProcessor(
+                md,
+                caption_prefix=self.getConfig("caption_prefix"),
+                numbering=self.getConfig("numbering"),
+                caption_prefix_class=self.getConfig("caption_prefix_class"),
+                caption_class=self.getConfig("caption_class"),
+                content_class=self.getConfig("content_class"),
+                strip_title=self.getConfig("strip_title"),
+            ),
+            "figurecaptiontreeprocessor",
+            8,
+        )
+
+
+def makeExtension(**kwargs):
+    return ImageCaptionExtension(**kwargs)

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -89,6 +89,7 @@ class ImageCaptionExtension(Extension):
             "caption_class": ["", "CSS class to add to the caption element."],
             "content_class": ["", "CSS class to add to the content element."],
             "strip_title": [True, "Remove the title from the img tag."],
+            "caption_top": [False, "Put the caption at the top of the image."],
         }
         super(ImageCaptionExtension, self).__init__(**kwargs)
 

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -29,14 +29,16 @@ class ImageCaptionTreeProcessor(CaptionTreeprocessor):
         caption_class=None,
         content_class=None,
         strip_title=True,
+        caption_top=False,
     ):
         super(ImageCaptionTreeProcessor, self).__init__(
-            md,
-            caption_prefix,
-            numbering,
-            caption_prefix_class,
-            caption_class,
-            content_class
+            md=md,
+            caption_prefix=caption_prefix,
+            numbering=numbering,
+            caption_prefix_class=caption_prefix_class,
+            caption_class=caption_class,
+            content_class=content_class,
+            caption_top=caption_top,
         )
         self.strip_title = strip_title
 
@@ -53,8 +55,8 @@ class ImageCaptionTreeProcessor(CaptionTreeprocessor):
     def get_title(self, par):
         return self._img.get("title")
 
-    def build_content_element(self, par):
-        super(ImageCaptionTreeProcessor, self).build_content_element(par)
+    def build_content_element(self, par, caption, replace=True):
+        super(ImageCaptionTreeProcessor, self).build_content_element(par, caption, replace=replace)
         if self._a is not None:
             self._a.tail = "\n"
             par.append(self._a)
@@ -62,10 +64,11 @@ class ImageCaptionTreeProcessor(CaptionTreeprocessor):
             self._img.tail = self._img.tail or "" + "\n"
             par.append(self._img)
 
-    def build_caption_element(self, par, title):
-        super(ImageCaptionTreeProcessor, self).build_caption_element(par, title)
+    def build_caption_element(self, title):
+        caption = super(ImageCaptionTreeProcessor, self).build_caption_element(title)
         if self.strip_title and title:
             del self._img.attrib["title"]
+        return caption
 
 
 class ImageCaptionExtension(Extension):
@@ -91,15 +94,7 @@ class ImageCaptionExtension(Extension):
 
     def extendMarkdown(self, md):
         md.treeprocessors.register(
-            ImageCaptionTreeProcessor(
-                md,
-                caption_prefix=self.getConfig("caption_prefix"),
-                numbering=self.getConfig("numbering"),
-                caption_prefix_class=self.getConfig("caption_prefix_class"),
-                caption_class=self.getConfig("caption_class"),
-                content_class=self.getConfig("content_class"),
-                strip_title=self.getConfig("strip_title"),
-            ),
+            ImageCaptionTreeProcessor(md, **self.getConfigs()),
             "figurecaptiontreeprocessor",
             8,
         )

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -13,7 +13,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 from markdown import Extension
 
-from caption.caption import CaptionTreeprocessor
+from .caption import CaptionTreeprocessor
 
 
 class ImageCaptionTreeProcessor(CaptionTreeprocessor):

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -10,7 +10,7 @@ from xml.etree import ElementTree
 
 from markdown import Extension
 
-from caption.caption import CaptionTreeprocessor
+from .caption import CaptionTreeprocessor
 
 
 class TableCaptionTreeProcessor(CaptionTreeprocessor):

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -1,0 +1,73 @@
+# caption - Manage markdown captions
+#
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
+# forked from yafg - https://git.sr.ht/~ferruck/yafg
+# Copyright (c) 2019 Philipp Trommler
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+from xml.etree import ElementTree
+
+from markdown import Extension
+
+from caption.caption import CaptionTreeprocessor
+
+
+class TableCaptionTreeProcessor(CaptionTreeprocessor):
+    name = "table"
+    content_tag = "table"
+    caption_tag = "caption"
+
+    def matches(self, par):
+        return par.text and par.text.startswith("Table: ")
+
+    def get_title(self, par):
+        return par.text[7:]
+
+    def run(self, root):
+        """Find and format all captions."""
+        root_iterator = iter(root)
+        for child in root_iterator:
+            if child.tag != "p" or not self.matches(child):
+                continue
+            next_item = next(root_iterator)
+            if next_item.tag != self.content_tag:
+                continue
+            self.number += 1
+            title = self.get_title(child)
+            root.remove(child)
+            caption = self.build_caption_element(title)
+            self.build_content_element(next_item, caption, replace=False)
+            self.add_caption_to_content(next_item, caption)
+
+
+class TableCaptionExtension(Extension):
+    # caption Extension
+
+    def __init__(self, **kwargs):
+        # Setup configs
+        self.config = {
+            "caption_prefix": [
+                "Table",
+                "The text to show in front of the table caption.",
+            ],
+            "numbering": [True, "Add the caption number to the prefix."],
+            "caption_prefix_class": [
+                "",
+                "CSS class to add to the caption prefix <span /> element.",
+            ],
+            "caption_class": ["", "CSS class to add to the caption element."],
+            "content_class": ["", "CSS class to add to the content element."],
+        }
+        super(TableCaptionExtension, self).__init__(**kwargs)
+
+    def extendMarkdown(self, md):
+        md.treeprocessors.register(
+            TableCaptionTreeProcessor(md, **self.getConfigs()),
+            "tablecaptiontreeprocessor",
+            8,
+        )
+
+
+def makeExtension(**kwargs):
+    return TableCaptionExtension(**kwargs)

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -24,6 +24,11 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
     def get_title(self, par):
         return par.text[7:]
 
+    def add_caption_to_content(self, content, caption):
+        if not self.caption_top:
+            caption.set("style", "caption-side:bottom")
+        content.insert(0, caption)
+
     def run(self, root):
         """Find and format all captions."""
         root_iterator = iter(root)
@@ -58,6 +63,7 @@ class TableCaptionExtension(Extension):
             ],
             "caption_class": ["", "CSS class to add to the caption element."],
             "content_class": ["", "CSS class to add to the content element."],
+            "caption_top": [True, "Put the caption at the top of the table."],
         }
         super(TableCaptionExtension, self).__init__(**kwargs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,4 @@
 Markdown>=3.1.1
+pytest
+pytest-cov
+coverage

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuptools.setup(
         "markdown.extensions": [
             "caption = caption:CaptionExtension",
             "image_captions = caption:ImageCaptionExtension",
+            "table_captions = caption:TableCaptionExtension",
         ]
     },
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 # caption - Manage markdown captions
 #
-# Copyright (c) 2020 flywire
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,12 @@ setuptools.setup(
         "Topic :: Text Processing :: Markup",
     ],
     description="Manage markdown captions extension",
-    entry_points={"markdown.extensions": ["caption = caption:CaptionExtension"]},
+    entry_points={
+        "markdown.extensions": [
+            "caption = caption:CaptionExtension",
+            "image_captions = caption:ImageCaptionExtension",
+        ]
+    },
     install_requires=requirements,
     keywords="markdown image figure caption html a11y",
     license="GPLv3+",

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,6 @@
 # caption: Manage markdown captions
 #
-# Copyright (c) 2020 flywire
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/test/test_caption.py
+++ b/test/test_caption.py
@@ -1,6 +1,7 @@
 # caption - Manage markdown captions
 #
-# Copyright (c) 2020 flywire
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/test/test_caption.py
+++ b/test/test_caption.py
@@ -9,11 +9,12 @@
 import markdown
 
 from caption import CaptionExtension
+from caption import ImageCaptionExtension
 
 
 def test_empty_input():
     in_string = ""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == in_string
 
 
@@ -32,7 +33,7 @@ It contains multiple paragraphs as well as [links](https://example.com).
 
 Nothing should change here whilst using caption."""
     expected_string = markdown.markdown(in_string)
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -55,7 +56,7 @@ def test_simple_image():
 <img alt="alt text" src="/path/to/image.png" />
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -67,7 +68,7 @@ def test_simple_image_without_title():
 <img alt="alt text" src="/path/to/image.png" />
 <figcaption><span>Figure&nbsp;1</span></figcaption>
 </figure>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -81,7 +82,7 @@ necessary to describe a picture for the blind.](/path/to/image.png "Title")"""
 necessary to describe a picture for the blind." src="/path/to/image.png" />
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -95,7 +96,7 @@ as sources.")"""
 <img alt="alt text" src="/path/to/image.png" />
 <figcaption><span>Figure&nbsp;1:</span> This is a very long title. It is used to give the readers a good figcaption. It may contain a description of the image as well as sources.</figcaption>
 </figure>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -110,9 +111,9 @@ def test_multiline_title_no_strip():
     out_string = markdown.markdown(
         in_string,
         extensions=[
-            CaptionExtension(
-                link_process="none",
-                figure_caption_prefix="",
+            ImageCaptionExtension(
+                strip_title=False,
+                caption_prefix="",
                 numbering=False,
             )
         ],
@@ -129,7 +130,7 @@ def test_strip_title_none():
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=[CaptionExtension(link_process="none")]
+        in_string, extensions=[ImageCaptionExtension(strip_title=False)]
     )
     assert out_string == expected_string
 
@@ -143,7 +144,7 @@ def test_content_class():
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=[CaptionExtension(content_class="testclass")]
+        in_string, extensions=[ImageCaptionExtension(content_class="testclass")]
     )
     assert out_string == expected_string
 
@@ -157,7 +158,7 @@ def test_caption_class():
 <figcaption class="testclass"><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=[CaptionExtension(caption_class="testclass")]
+        in_string, extensions=[ImageCaptionExtension(caption_class="testclass")]
     )
     assert out_string == expected_string
 
@@ -177,7 +178,7 @@ def test_numbering_false():
 <figcaption>Title 2</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=[CaptionExtension(numbering=False)]
+        in_string, extensions=[ImageCaptionExtension(numbering=False)]
     )
     assert out_string == expected_string
 
@@ -192,7 +193,7 @@ def test_caption_prefix_class():
 </figure>"""
     out_string = markdown.markdown(
         in_string,
-        extensions=[CaptionExtension(caption_prefix_class="testclass")],
+        extensions=[ImageCaptionExtension(caption_prefix_class="testclass")],
     )
     assert out_string == expected_string
 
@@ -206,7 +207,7 @@ def test_caption_prefix():
 <figcaption><span>Abbildung&nbsp;1:</span> Title</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=[CaptionExtension(figure_caption_prefix="Abbildung")]
+        in_string, extensions=[ImageCaptionExtension(caption_prefix="Abbildung")]
     )
     assert out_string == expected_string
 
@@ -220,7 +221,7 @@ def test_attribute_preservation():
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
     out_string = markdown.markdown(
-        in_string, extensions=["attr_list", CaptionExtension()]
+        in_string, extensions=["attr_list", ImageCaptionExtension()]
     )
     assert out_string == expected_string
 
@@ -233,7 +234,7 @@ def test_image_in_link():
 <a href="/path/to/link.html"><img alt="alt text" src="/path/to/image.png" /></a>
 <figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
 </figure>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
     assert out_string == expected_string
 
 
@@ -248,13 +249,13 @@ def test_combined_options():
     out_string = markdown.markdown(
         in_string,
         extensions=[
-            CaptionExtension(
-                figure_caption_prefix="Abbildung",
+            ImageCaptionExtension(
+                caption_prefix="Abbildung",
                 numbering=True,
                 content_class="testclass1",
                 caption_class="testclass2",
                 caption_prefix_class="testclass3",
-                link_process="strip_title",
+                strip_title=True,
             )
         ],
     )

--- a/test/test_image_caption.py
+++ b/test/test_image_caption.py
@@ -8,7 +8,6 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import markdown
 
-from caption import CaptionExtension
 from caption import ImageCaptionExtension
 
 
@@ -34,17 +33,6 @@ It contains multiple paragraphs as well as [links](https://example.com).
 Nothing should change here whilst using caption."""
     expected_string = markdown.markdown(in_string)
     out_string = markdown.markdown(in_string, extensions=[ImageCaptionExtension()])
-    assert out_string == expected_string
-
-
-def test_listing():
-    in_string = """\
-Listing: Simple listing test"""
-    expected_string = """\
-<div class=listing id="_listing-1">
-<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
-</div class=listing>"""
-    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
     assert out_string == expected_string
 
 

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -1,0 +1,22 @@
+# caption - Manage markdown captions
+#
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
+# forked from yafg - https://git.sr.ht/~ferruck/yafg
+# Copyright (c) 2019 Philipp Trommler
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+import markdown
+
+from caption import CaptionExtension
+
+
+def test_listing():
+    in_string = """\
+Listing: Simple listing test"""
+    expected_string = """\
+<div class=listing id="_listing-1">
+<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
+</div class=listing>"""
+    out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -8,7 +8,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import markdown
 
-from caption import CaptionExtension
+from caption.caption import CaptionExtension
 
 
 def test_listing():

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -36,8 +36,7 @@ Nothing should change here whilst using caption."""
     assert out_string == expected_string
 
 
-def test_simple_table():
-    in_string = """\
+BASE_MD_TABLE = """\
 Table: Example with heading, two columns and a row
 
 | Syntax      | Description |
@@ -45,58 +44,91 @@ Table: Example with heading, two columns and a row
 | Header      | Title       |
 | Paragraph   | Text        |
 """
+
+
+TABLE_INNER_CONTENT = """<thead>
+<tr>
+<th>Syntax</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Header</td>
+<td>Title</td>
+</tr>
+<tr>
+<td>Paragraph</td>
+<td>Text</td>
+</tr>
+</tbody>"""
+
+
+def test_defaults():
     expected_string = """\
 <table id="_table-1">
 <caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
-<thead>
-<tr>
-<th>Syntax</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Header</td>
-<td>Title</td>
-</tr>
-<tr>
-<td>Paragraph</td>
-<td>Text</td>
-</tr>
-</tbody>
-</table>"""
-    out_string = markdown.markdown(in_string, extensions=["tables", TableCaptionExtension()])
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension()])
     assert out_string == expected_string
 
 
-def test_simple_table_bottom_caption():
-    in_string = """\
-Table: Example with heading, two columns and a row
-
-| Syntax      | Description |
-| ----------- | ----------- |
-| Header      | Title       |
-| Paragraph   | Text        |
-"""
+def test_bottom_caption():
     expected_string = """\
 <table id="_table-1">
 <caption style="caption-side:bottom"><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
-<thead>
-<tr>
-<th>Syntax</th>
-<th>Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Header</td>
-<td>Title</td>
-</tr>
-<tr>
-<td>Paragraph</td>
-<td>Text</td>
-</tr>
-</tbody>
-</table>"""
-    out_string = markdown.markdown(in_string, extensions=["tables", TableCaptionExtension(caption_top=False)])
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_top=False)])
+    assert out_string == expected_string
+
+
+def test_content_class():
+    expected_string = """\
+<table class="testclass" id="_table-1">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(content_class="testclass")])
+    assert out_string == expected_string
+
+
+def test_caption_class():
+    expected_string = """\
+<table id="_table-1">
+<caption class="testclass"><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_class="testclass")])
+    assert out_string == expected_string
+
+
+def test_no_numbering():
+    expected_string = """\
+<table id="_table-1">
+<caption>Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(numbering=False)])
+    assert out_string == expected_string
+
+
+def test_caption_prefix_class():
+    expected_string = """\
+<table id="_table-1">
+<caption><span class="testclass">Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_prefix_class="testclass")])
+    assert out_string == expected_string
+
+
+def test_caption_prefix():
+    expected_string = """\
+<table id="_table-1">
+<caption><span>Tabula&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_prefix="Tabula")])
     assert out_string == expected_string

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -1,0 +1,69 @@
+# caption - Manage markdown captions
+#
+# Copyright (c) 2020-2023 flywire
+# Copyright (c) 2023 sanzoghenzo
+# forked from yafg - https://git.sr.ht/~ferruck/yafg
+# Copyright (c) 2019 Philipp Trommler
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+import markdown
+
+from caption import TableCaptionExtension
+
+
+def test_empty_input():
+    in_string = ""
+    out_string = markdown.markdown(in_string, extensions=[TableCaptionExtension()])
+    assert out_string == in_string
+
+
+def test_no_table():
+    in_string = """\
+This is a test text.
+
+It contains multiple paragraphs as well as [links](https://example.com).
+
+* Itemize
+* is
+* used,
+* as well.
+
+# This is a headline.
+
+Nothing should change here whilst using caption."""
+    expected_string = markdown.markdown(in_string)
+    out_string = markdown.markdown(in_string, extensions=[TableCaptionExtension()])
+    assert out_string == expected_string
+
+
+def test_simple_table():
+    in_string = """\
+Table: Example with heading, two columns and a row
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+"""
+    expected_string = """\
+<table id="_table-1">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+<thead>
+<tr>
+<th>Syntax</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Header</td>
+<td>Title</td>
+</tr>
+<tr>
+<td>Paragraph</td>
+<td>Text</td>
+</tr>
+</tbody>
+</table>"""
+    out_string = markdown.markdown(in_string, extensions=["tables", TableCaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -67,3 +67,36 @@ Table: Example with heading, two columns and a row
 </table>"""
     out_string = markdown.markdown(in_string, extensions=["tables", TableCaptionExtension()])
     assert out_string == expected_string
+
+
+def test_simple_table_bottom_caption():
+    in_string = """\
+Table: Example with heading, two columns and a row
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+"""
+    expected_string = """\
+<table id="_table-1">
+<caption style="caption-side:bottom"><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+<thead>
+<tr>
+<th>Syntax</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>Header</td>
+<td>Title</td>
+</tr>
+<tr>
+<td>Paragraph</td>
+<td>Text</td>
+</tr>
+</tbody>
+</table>"""
+    out_string = markdown.markdown(in_string, extensions=["tables", TableCaptionExtension(caption_top=False)])
+    assert out_string == expected_string


### PR DESCRIPTION
Hi,
these changes should fix most of what we talked about.

There are now 3 plugins, one for images, one for tables and one for generic listings (that will need some more work).

Unit tests are in place also for tables, and they all pass.

I've updated the readme to illustrate the functionality and explain the config defaults.