### PR TITLE
Fix/add compatibility with attr_list extension ids, classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The default values for each type of content is synthesised in the following tabl
 |------------------------|---------|---------|-----------|
 | `caption_prefix`       | "Image" | "Table" | "Listing" |
 | `numbering`            | False   | False   | False     |
-| `content_class`        | -       | -       | -         |
+| `content_class`        | -       | -       | listing   |
 | `caption_class`        | -       | -       | -         |
 | `caption_prefix_class` | -       | -       | -         |
 | `caption_top`          | False   | True    | True      |
@@ -225,6 +225,67 @@ figcaption span:first-child {
 }
 ```
  There are further examples in the [wiki](https://github.com/flywire/caption/wiki).
+
+## Compatibility with attr_list extension
+
+*caption* supports preserving `attr_list` extension supplied `id` and `class` attributes by:
+
+* giving priority to markdown defined `id` attributes
+* concatenating `class` attributes.
+
+### `image_captions`
+
+This samples shows how to create a captioned image with `id` and `class` through markdown `attr_list` extension.
+
+```markdown
+![Alt text](/path/to/image.png "This is the title of the image."){ #title-image .test-class }
+```
+
+becomes
+
+```html
+<figure id="_figure-1">
+<img alt="Alt text" src="/path/to/image.png" id="title-image" class="test-class" />
+    ...
+```
+
+### `table_captions`
+
+This samples shows how to create a captioned table with `id` and `class` through markdown `attr_list` extension.
+
+```markdown
+Table: Example with heading, two columns and a row
+{#example-with-heading .test-class}
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+```
+
+becomes
+
+```html
+<table id="example-with-heading" class="test-class table">
+    ...
+```
+
+### `caption`
+
+This samples shows how to create a generic caption with `id` and `class` through markdown `attr_list` extension.
+
+
+```markdown
+Listing: Example listing
+{ #example-listing .test-class }
+```
+
+becomes
+
+```html
+<div class="listing test-class" id="example-listing">
+<figcaption><span>Listing&nbsp;1:</span> Example listing</figcaption>
+</div>
+```
 
 ## Customisable
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Listing: Example listing
 becomes
 
 ```html
-<caption><span>Listing&nbsp;1:</span> Example listing</caption>
+<div class="listing" id="_listing-1">
+<figcaption><span>Listing&nbsp;1:</span> Example listing</figcaption>
+</div>
 ```
 
 ## How?

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -52,9 +52,16 @@ class CaptionTreeprocessor(Treeprocessor):
         par.tag = self.content_tag
         for k, v in attrib.items():
             par.set(k, v)
+
         if self.content_class:
-            par.set("class", self.content_class)
-        par.set("id", "_{}-{}".format(self.name, self.number))
+            if not "class" in attrib:
+                par.set("class", self.content_class)
+            else:
+                par.set("class", self.content_class + " " + attrib["class"])
+
+        if not "id" in attrib:
+            par.set("id", "_{}-{}".format(self.name, self.number))
+            
         if replace:
             par.text = "\n"
         par.tail = "\n"
@@ -116,7 +123,7 @@ class CaptionTreeprocessor(Treeprocessor):
 
 class ListingCaptionTreeProcessor(CaptionTreeprocessor):
     name = "listing"
-    content_tag = "div class=listing"
+    content_tag = "div"
 
     def matches(self, par):
         return par.text and par.text.startswith("Listing: ")
@@ -141,7 +148,7 @@ class CaptionExtension(Extension):
                 "CSS class to add to the caption prefix <span /> element.",
             ],
             "caption_class": ["", "CSS class to add to the caption element."],
-            "content_class": ["", "CSS class to add to the content element."],
+            "content_class": ["listing", "CSS class to add to the content element."],
             "link_process": ["", "Some content types support linked processes."],
             "caption_top": [False, "Put the caption at the top of the content."],
         }

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -54,14 +54,13 @@ class CaptionTreeprocessor(Treeprocessor):
             par.set(k, v)
 
         if self.content_class:
-            if not "class" in attrib:
-                par.set("class", self.content_class)
-            else:
+            if "class" in attrib:
                 par.set("class", self.content_class + " " + attrib["class"])
-
-        if not "id" in attrib:
+            else:
+                par.set("class", self.content_class)
+        if "id" not in attrib:
             par.set("id", "_{}-{}".format(self.name, self.number))
-            
+
         if replace:
             par.text = "\n"
         par.tail = "\n"

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -42,6 +42,16 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
             title = self.get_title(child)
             root.remove(child)
             caption = self.build_caption_element(title)
+            
+            attrib = child.attrib
+            if "class" in attrib:
+                if not "class" in next_item.attrib:
+                    next_item.set("class", attrib["class"])
+                else:
+                    next_item.set("class", attrib["class"] + " " + next_item.attrib["class"])
+            if "id" in attrib:
+                next_item.set("id", attrib["id"])
+
             self.build_content_element(next_item, caption, replace=False)
             self.add_caption_to_content(next_item, caption)
 

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -6,7 +6,6 @@
 # Copyright (c) 2019 Philipp Trommler
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from xml.etree import ElementTree
 
 from markdown import Extension
 
@@ -42,13 +41,14 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
             title = self.get_title(child)
             root.remove(child)
             caption = self.build_caption_element(title)
-            
+
             attrib = child.attrib
             if "class" in attrib:
-                if not "class" in next_item.attrib:
-                    next_item.set("class", attrib["class"])
+                if "class" in next_item.attrib:
+                    next_item.set("class", attrib["class"] +
+                                  " " + next_item.attrib["class"])
                 else:
-                    next_item.set("class", attrib["class"] + " " + next_item.attrib["class"])
+                    next_item.set("class", attrib["class"])
             if "id" in attrib:
                 next_item.set("id", attrib["id"])
 

--- a/test/test_image_caption.py
+++ b/test/test_image_caption.py
@@ -248,3 +248,15 @@ def test_combined_options():
         ],
     )
     assert out_string == expected_string
+
+
+def test_image_attr_list():
+    in_string = """\
+![alt text](/path/to/image.png "Title"){#testid .testal}"""
+    expected_string = """\
+<figure id="_figure-1">
+<img alt="alt text" class="testal" id="testid" src="/path/to/image.png" />
+<figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
+</figure>"""
+    out_string = markdown.markdown(in_string, extensions=["attr_list", ImageCaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -20,3 +20,15 @@ Listing: Simple listing test"""
 </div>"""
     out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
     assert out_string == expected_string
+
+
+def test_listing_attr_list():
+    in_string = """\
+Listing: Simple listing test\n\
+{#testid .testclass}"""
+    expected_string = """\
+<div class="listing testclass" id="testid">
+<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
+</div>"""
+    out_string = markdown.markdown(in_string, extensions=["attr_list", CaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -15,8 +15,8 @@ def test_listing():
     in_string = """\
 Listing: Simple listing test"""
     expected_string = """\
-<div class=listing id="_listing-1">
+<div class="listing" id="_listing-1">
 <figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
-</div class=listing>"""
+</div>"""
     out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
     assert out_string == expected_string

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -64,6 +64,17 @@ TABLE_INNER_CONTENT = """<thead>
 </tbody>"""
 
 
+BASE_MD_TABLE_ATTR_LIST = """\
+Table: Example with heading, two columns and a row
+{#testid .testal}
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+"""
+
+
 def test_defaults():
     expected_string = """\
 <table id="_table-1">
@@ -131,4 +142,24 @@ def test_caption_prefix():
 {}
 </table>""".format(TABLE_INNER_CONTENT)
     out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_prefix="Tabula")])
+    assert out_string == expected_string
+
+
+def test_attr_list():
+    expected_string = """\
+<table class="testal" id="testid">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE_ATTR_LIST, extensions=["attr_list", "tables", TableCaptionExtension()])
+    assert out_string == expected_string
+
+
+def test_content_class_attr_list():
+    expected_string = """\
+<table class="testclass testal" id="testid">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE_ATTR_LIST, extensions=["attr_list", "tables", TableCaptionExtension(content_class="testclass")])
     assert out_string == expected_string


### PR DESCRIPTION
This fixes/adds the compatibility to supply custom anchor id, and class through the markdown text (through attr_list extension).

* I also fixed the readme in regard how generic caption (Listings) are html rendered.
* generic captions had a html-syntax errors previously in closing tag (contained class=listing statically)
  * this is fixed now

In regard to usage please see updated readme + unit tests.

Goal is to be able to be able to specify permalink / anchorid's to the resulting captions/elements in general through the attr_list extension. If no markdown `attr_list` specified the *caption* extension will still fallback to the previous id generation method.