### PR TITLE
New config options / features

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ The default values for each type of content is synthesised in the following tabl
 |------------------------|---------|---------|-----------|
 | `caption_prefix`       | "Image" | "Table" | "Listing" |
 | `numbering`            | False   | False   | False     |
-| `content_class`        | -       | -       | -         |
+| `content_class`        | -       | -       | listing   |
 | `caption_class`        | -       | -       | -         |
 | `caption_prefix_class` | -       | -       | -         |
 | `caption_top`          | False   | True    | True      |
@@ -225,6 +225,67 @@ figcaption span:first-child {
 }
 ```
  There are further examples in the [wiki](https://github.com/flywire/caption/wiki).
+
+## Compatibility with attr_list extension
+
+*caption* supports preserving `attr_list` extension supplied `id` and `class` attributes by:
+
+* giving priority to markdown defined `id` attributes
+* concatenating `class` attributes.
+
+### `image_captions`
+
+This samples shows how to create a captioned image with `id` and `class` through markdown `attr_list` extension.
+
+```markdown
+![Alt text](/path/to/image.png "This is the title of the image."){ #title-image .test-class }
+```
+
+becomes
+
+```html
+<figure id="_figure-1">
+<img alt="Alt text" src="/path/to/image.png" id="title-image" class="test-class" />
+    ...
+```
+
+### `table_captions`
+
+This samples shows how to create a captioned table with `id` and `class` through markdown `attr_list` extension.
+
+```markdown
+Table: Example with heading, two columns and a row
+{#example-with-heading .test-class}
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+```
+
+becomes
+
+```html
+<table id="example-with-heading" class="test-class table">
+    ...
+```
+
+### `caption`
+
+This samples shows how to create a generic caption with `id` and `class` through markdown `attr_list` extension.
+
+
+```markdown
+Listing: Example listing
+{ #example-listing .test-class }
+```
+
+becomes
+
+```html
+<div class="listing test-class" id="example-listing">
+<figcaption><span>Listing&nbsp;1:</span> Example listing</figcaption>
+</div>
+```
 
 ## Customisable
 

--- a/README.md
+++ b/README.md
@@ -145,10 +145,30 @@ Currently supported options are listed below:
     is inserted between the content of `caption_prefix` and the actual figure
     number.
 
+* `caption_match_re`
+
+    The regexp used to match captions from the markdown text. It can be used
+    to match captions from multiple languages at once.
+    The `group(number)` can match a optional `number`, see `numbering_preserve`.
+    The `group(title)` needs to match the `title`.
+
+* `caption_skip_empty`
+
+    Whether empty captions should be skipped. This can be used for example to
+    skip images that are used as icons (captions which have an empty `title`).
+
 * `numbering`:
 
     Adds a caption number like "Figure 1:" in front of the caption. It's
 	wrapped in a `<span />` for easier styling.
+
+* `numbering_preserve`
+
+    This preserves a number captured to the `group(number)` using the
+    `caption_match_re` option. If no number is present it falls back to
+    the number generated from `numbering` option behaviour. It is not
+    recommended to use `preserved` manual and automatic numbering at
+    the same time in the markdown text, because of the conflict potential.
 
 * `content_class`:
 
@@ -171,7 +191,10 @@ The default values for each type of content is synthesised in the following tabl
 | Config                 | Image   | Table   | Other     |
 |------------------------|---------|---------|-----------|
 | `caption_prefix`       | "Image" | "Table" | "Listing" |
+| `caption_match_re`     | - (not supported) | `^Table\s*?(?P<number>\d*)\:\s*(?P<title>.*)` | `^Listing\s*?(?P<number>\d*)\:\s*(?P<title>.*)` |
+| `caption_skip_empty`   | False   | False   | False     |
 | `numbering`            | False   | False   | False     |
+| `numbering_preserve`   | False   | False   | False     |
 | `content_class`        | -       | -       | listing   |
 | `caption_class`        | -       | -       | -         |
 | `caption_prefix_class` | -       | -       | -         |

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ Listing: Example listing
 becomes
 
 ```html
-<caption><span>Listing&nbsp;1:</span> Example listing</caption>
+<div class="listing" id="_listing-1">
+<figcaption><span>Listing&nbsp;1:</span> Example listing</figcaption>
+</div>
 ```
 
 ## How?

--- a/caption/__init__.py
+++ b/caption/__init__.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -52,9 +52,16 @@ class CaptionTreeprocessor(Treeprocessor):
         par.tag = self.content_tag
         for k, v in attrib.items():
             par.set(k, v)
+
         if self.content_class:
-            par.set("class", self.content_class)
-        par.set("id", "_{}-{}".format(self.name, self.number))
+            if not "class" in attrib:
+                par.set("class", self.content_class)
+            else:
+                par.set("class", self.content_class + " " + attrib["class"])
+
+        if not "id" in attrib:
+            par.set("id", "_{}-{}".format(self.name, self.number))
+            
         if replace:
             par.text = "\n"
         par.tail = "\n"
@@ -116,7 +123,7 @@ class CaptionTreeprocessor(Treeprocessor):
 
 class ListingCaptionTreeProcessor(CaptionTreeprocessor):
     name = "listing"
-    content_tag = "div class=listing"
+    content_tag = "div"
 
     def matches(self, par):
         return par.text and par.text.startswith("Listing: ")
@@ -141,7 +148,7 @@ class CaptionExtension(Extension):
                 "CSS class to add to the caption prefix <span /> element.",
             ],
             "caption_class": ["", "CSS class to add to the caption element."],
-            "content_class": ["", "CSS class to add to the content element."],
+            "content_class": ["listing", "CSS class to add to the content element."],
             "link_process": ["", "Some content types support linked processes."],
             "caption_top": [False, "Put the caption at the top of the content."],
         }

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -124,6 +124,9 @@ class ListingCaptionTreeProcessor(CaptionTreeprocessor):
     name = "listing"
     content_tag = "div"
 
+    def __init__(self, *args, **kwargs):
+        super(ListingCaptionTreeProcessor, self).__init__(*args, **kwargs)
+
     def matches(self, par):
         return par.text and par.text.startswith("Listing: ")
 

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -42,7 +42,7 @@ class CaptionTreeprocessor(Treeprocessor):
         self.caption_prefix = caption_prefix
         self.caption_match_re = caption_match_re
         self._match_re = re.compile(self.caption_match_re)
-        self.caption_skip_empty = caption_skip_empty,
+        self.caption_skip_empty = caption_skip_empty
         self.numbering = numbering
         self.numbering_preserve = numbering_preserve
         self.number = 0
@@ -130,9 +130,13 @@ class CaptionTreeprocessor(Treeprocessor):
         Remember the determined number, title.
         Determines if the current match should not be skipped.
         """
-        if title is not None:
+        valid = True
+        if title is None:
+            valid = False
+        else:
             title = title.strip()
-        valid = not self.caption_skip_empty or title
+            valid &= len(title) > 0
+        valid |= not self.caption_skip_empty
         if valid:
             self._match_title = title or ""
             try:
@@ -141,7 +145,9 @@ class CaptionTreeprocessor(Treeprocessor):
                 pass
             except ValueError:
                 pass
-        return True
+        else:
+            self.reset_match()
+        return valid
 
     def get_title(self):
         """Title of the matched figure. This can be overriden by the subclasses."""

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -15,6 +15,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 from markdown.treeprocessors import Treeprocessor
 from markdown.extensions import Extension
 from xml.etree import ElementTree
+import re
 
 
 class CaptionTreeprocessor(Treeprocessor):
@@ -28,7 +29,10 @@ class CaptionTreeprocessor(Treeprocessor):
         self,
         md=None,
         caption_prefix="",
+        caption_match_re="",
+        caption_skip_empty=False,
         numbering=True,
+        numbering_preserve=False,
         caption_prefix_class=None,
         caption_class=None,
         content_class=None,
@@ -36,13 +40,20 @@ class CaptionTreeprocessor(Treeprocessor):
         caption_top=True,
     ):
         self.caption_prefix = caption_prefix
+        self.caption_match_re = caption_match_re
+        self._match_re = re.compile(self.caption_match_re)
+        self.caption_skip_empty = caption_skip_empty,
         self.numbering = numbering
+        self.numbering_preserve = numbering_preserve
         self.number = 0
         self.caption_prefix_class = caption_prefix_class
         self.caption_class = caption_class
         self.content_class = content_class
         self.link_process = link_process
         self.caption_top = caption_top
+
+        self._match_title = ""
+        self._match_number = None
 
     def build_content_element(self, par, caption, replace=True):
         """Format the content element containing the caption"""
@@ -59,7 +70,7 @@ class CaptionTreeprocessor(Treeprocessor):
             else:
                 par.set("class", self.content_class)
         if "id" not in attrib:
-            par.set("id", "_{}-{}".format(self.name, self.number))
+            par.set("id", "_{}-{}".format(self.name, self.get_number()))
 
         if replace:
             par.text = "\n"
@@ -84,12 +95,12 @@ class CaptionTreeprocessor(Treeprocessor):
         caption_prefix_span = ElementTree.SubElement(caption, "span")
         if title:
             caption_prefix_span.text = "{}&nbsp;{}:".format(
-                self.caption_prefix, self.number
+                self.caption_prefix, self.get_number()
             )
             caption_prefix_span.tail = " {}".format(title)
         else:
             caption_prefix_span.text = "{}&nbsp;{}".format(
-                self.caption_prefix, self.number
+                self.caption_prefix, self.get_number()
             )
             caption_prefix_span.tail = ""
         if self.caption_prefix_class:
@@ -99,14 +110,48 @@ class CaptionTreeprocessor(Treeprocessor):
     def matches(self, par):
         """
         Whether the element tree part matches the object to be captioned.
-
-        This will be overriden by the subclasses.
+        This can be overriden by the subclasses.
         """
-        raise NotImplementedError
+        self.reset_match()
+        if par.text:
+            match_caption = self._match_re.match(par.text)
+            if match_caption is not None:
+                return self.match_valid(match_caption.group("title"),
+                                        match_caption.group("number"))
+        return False
 
-    def get_title(self, par):
-        """Title of the element. This will be overriden by the subclasses."""
-        raise NotImplementedError
+    def reset_match(self):
+        """Resets the last found caption match data."""
+        self._match_title = ""
+        self._match_number = None
+
+    def match_valid(self, title="", number=None):
+        """
+        Remember the determined number, title.
+        Determines if the current match should not be skipped.
+        """
+        if title is not None:
+            title = title.strip()
+        valid = not self.caption_skip_empty or title
+        if valid:
+            self._match_title = title or ""
+            try:
+                self._match_number = int(number)
+            except TypeError:
+                pass
+            except ValueError:
+                pass
+        return True
+
+    def get_title(self):
+        """Title of the matched figure. This can be overriden by the subclasses."""
+        return self._match_title
+
+    def get_number(self):
+        """Number of the matched figure. This can be overriden by the subclasses."""
+        if self.numbering_preserve and self._match_number is not None:
+            return self._match_number
+        return self.number
 
     def run(self, root):
         """Find and format all captions."""
@@ -114,7 +159,7 @@ class CaptionTreeprocessor(Treeprocessor):
             if not self.matches(par):
                 continue
             self.number += 1
-            title = self.get_title(par)
+            title = self.get_title()
             caption = self.build_caption_element(title)
             self.build_content_element(par, caption)
             self.add_caption_to_content(par, caption)
@@ -127,12 +172,6 @@ class ListingCaptionTreeProcessor(CaptionTreeprocessor):
     def __init__(self, *args, **kwargs):
         super(ListingCaptionTreeProcessor, self).__init__(*args, **kwargs)
 
-    def matches(self, par):
-        return par.text and par.text.startswith("Listing: ")
-
-    def get_title(self, par):
-        return par.text[9:]
-
 
 class CaptionExtension(Extension):
     # caption Extension
@@ -144,7 +183,21 @@ class CaptionExtension(Extension):
                 "Listing",
                 "The text to show in front of the listing caption.",
             ],
+            "caption_match_re": [
+                r"^Listing\s*?(?P<number>\d*)\:\s*(?P<title>.*)",
+                "The regexp used to match captions."
+                "The group(number) can match a optional number."
+                "The group(title) needs to match the title.",
+            ],
+            "caption_skip_empty": [
+                False,
+                "Dont create captions for empty titles."
+            ],
             "numbering": [True, "Add the caption number to the prefix."],
+            "numbering_preserve": [
+                False,
+                "Preserve matched numbers from caption match."
+            ],
             "caption_prefix_class": [
                 "",
                 "CSS class to add to the caption prefix <span /> element.",

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -6,6 +6,7 @@ Applying style and auto-numbering to Python-Markdown content.
 https://github.com/flywire/caption
 Copyright (c) 2020-2023 flywire
 Copyright (c) 2023 sanzoghenzo
+Copyright (c) 2023 Hendrik Polczynski
 forked from yafg - https://git.sr.ht/~ferruck/yafg
 Copyright (c) 2019-2020 Philipp Trommler
 

--- a/caption/caption.py
+++ b/caption/caption.py
@@ -54,14 +54,13 @@ class CaptionTreeprocessor(Treeprocessor):
             par.set(k, v)
 
         if self.content_class:
-            if not "class" in attrib:
-                par.set("class", self.content_class)
-            else:
+            if "class" in attrib:
                 par.set("class", self.content_class + " " + attrib["class"])
-
-        if not "id" in attrib:
+            else:
+                par.set("class", self.content_class)
+        if "id" not in attrib:
             par.set("id", "_{}-{}".format(self.name, self.number))
-            
+
         if replace:
             par.text = "\n"
         par.tail = "\n"

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -20,27 +20,9 @@ class ImageCaptionTreeProcessor(CaptionTreeprocessor):
     name = "figure"
     content_tag = "figure"
 
-    def __init__(
-        self,
-        md=None,
-        caption_prefix="",
-        numbering=True,
-        caption_prefix_class=None,
-        caption_class=None,
-        content_class=None,
-        strip_title=True,
-        caption_top=False,
-    ):
-        super(ImageCaptionTreeProcessor, self).__init__(
-            md=md,
-            caption_prefix=caption_prefix,
-            numbering=numbering,
-            caption_prefix_class=caption_prefix_class,
-            caption_class=caption_class,
-            content_class=content_class,
-            caption_top=caption_top,
-        )
-        self.strip_title = strip_title
+    def __init__(self, *args, **kwargs):
+        self.strip_title = kwargs.pop("strip_title", True)
+        super(ImageCaptionTreeProcessor, self).__init__(*args, **kwargs)
 
     def matches(self, par):
         self._a = None

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -24,18 +24,22 @@ class ImageCaptionTreeProcessor(CaptionTreeprocessor):
         self.strip_title = kwargs.pop("strip_title", True)
         super(ImageCaptionTreeProcessor, self).__init__(*args, **kwargs)
 
-    def matches(self, par):
+    def reset_match(self):
+        super(ImageCaptionTreeProcessor, self).reset_match()
         self._a = None
+        self._img = None
+
+    def matches(self, par):
+        self.reset_match()
         self._img = par.find("./img")
         if self._img is None:
             self._a = par.find("./a")
-            if self._a is None:
-                return False
-            self._img = self._a.find("./img")
-        return self._img is not None
+            if self._a is not None:
+                self._img = self._a.find("./img")
 
-    def get_title(self, par):
-        return self._img.get("title")
+        if self._img is not None:
+            return self.match_valid(self._img.get("title"))
+        return False
 
     def build_content_element(self, par, caption, replace=True):
         super(ImageCaptionTreeProcessor, self).build_content_element(par, caption, replace=replace)
@@ -62,6 +66,10 @@ class ImageCaptionExtension(Extension):
             "caption_prefix": [
                 "Figure",
                 "The text to show in front of the image caption.",
+            ],
+            "caption_skip_empty": [
+                False,
+                "Dont create captions for empty titles."
             ],
             "numbering": [True, "Add the caption number to the prefix."],
             "caption_prefix_class": [

--- a/caption/image_caption.py
+++ b/caption/image_caption.py
@@ -6,6 +6,7 @@ Applying style and auto-numbering to Python-Markdown content.
 https://github.com/flywire/caption
 Copyright (c) 2020-2023 flywire
 Copyright (c) 2023 sanzoghenzo
+Copyright (c) 2023 Hendrik Polczynski
 forked from yafg - https://git.sr.ht/~ferruck/yafg
 Copyright (c) 2019-2020 Philipp Trommler
 

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -20,12 +20,6 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
     def __init__(self, *args, **kwargs):
         super(TableCaptionTreeProcessor, self).__init__(*args, **kwargs)
 
-    def matches(self, par):
-        return par.text and par.text.startswith("Table: ")
-
-    def get_title(self, par):
-        return par.text[7:]
-
     def add_caption_to_content(self, content, caption):
         if not self.caption_top:
             caption.set("style", "caption-side:bottom")
@@ -41,7 +35,7 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
             if next_item.tag != self.content_tag:
                 continue
             self.number += 1
-            title = self.get_title(child)
+            title = self.get_title()
             root.remove(child)
             caption = self.build_caption_element(title)
 
@@ -69,7 +63,21 @@ class TableCaptionExtension(Extension):
                 "Table",
                 "The text to show in front of the table caption.",
             ],
+            "caption_match_re": [
+                r"^Table\s*?(?P<number>\d*)\:\s*(?P<title>.*)",
+                "The regexp used to match captions."
+                "The group(number) can match a optional number."
+                "The group(title) needs to match the title.",
+            ],
+            "caption_skip_empty": [
+                False,
+                "Dont create captions for empty titles."
+            ],
             "numbering": [True, "Add the caption number to the prefix."],
+            "numbering_preserve": [
+                False,
+                "Preserve matched numbers from caption match."
+            ],
             "caption_prefix_class": [
                 "",
                 "CSS class to add to the caption prefix <span /> element.",

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -42,6 +42,16 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
             title = self.get_title(child)
             root.remove(child)
             caption = self.build_caption_element(title)
+            
+            attrib = child.attrib
+            if "class" in attrib:
+                if not "class" in next_item.attrib:
+                    next_item.set("class", attrib["class"])
+                else:
+                    next_item.set("class", attrib["class"] + " " + next_item.attrib["class"])
+            if "id" in attrib:
+                next_item.set("id", attrib["id"])
+
             self.build_content_element(next_item, caption, replace=False)
             self.add_caption_to_content(next_item, caption)
 

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -17,6 +17,9 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
     content_tag = "table"
     caption_tag = "caption"
 
+    def __init__(self, *args, **kwargs):
+        super(TableCaptionTreeProcessor, self).__init__(*args, **kwargs)
+
     def matches(self, par):
         return par.text and par.text.startswith("Table: ")
 

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/caption/table_caption.py
+++ b/caption/table_caption.py
@@ -6,7 +6,6 @@
 # Copyright (c) 2019 Philipp Trommler
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-from xml.etree import ElementTree
 
 from markdown import Extension
 
@@ -42,13 +41,14 @@ class TableCaptionTreeProcessor(CaptionTreeprocessor):
             title = self.get_title(child)
             root.remove(child)
             caption = self.build_caption_element(title)
-            
+
             attrib = child.attrib
             if "class" in attrib:
-                if not "class" in next_item.attrib:
-                    next_item.set("class", attrib["class"])
+                if "class" in next_item.attrib:
+                    next_item.set("class", attrib["class"] +
+                                  " " + next_item.attrib["class"])
                 else:
-                    next_item.set("class", attrib["class"] + " " + next_item.attrib["class"])
+                    next_item.set("class", attrib["class"])
             if "id" in attrib:
                 next_item.set("id", attrib["id"])
 

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -2,5 +2,6 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/test/test_image_caption.py
+++ b/test/test_image_caption.py
@@ -260,3 +260,38 @@ def test_image_attr_list():
 </figure>"""
     out_string = markdown.markdown(in_string, extensions=["attr_list", ImageCaptionExtension()])
     assert out_string == expected_string
+
+
+def test_simple_skip_image_without_title():
+    in_string = """\
+![alt text](/path/to/image.png)"""
+    expected_string = """\
+<p><img alt="alt text" src="/path/to/image.png" /></p>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            ImageCaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_simple_image_dont_skip_filled_title():
+    in_string = """\
+![alt text](/path/to/image.png "Title")"""
+    expected_string = """\
+<figure id="_figure-1">
+<img alt="alt text" src="/path/to/image.png" />
+<figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
+</figure>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            ImageCaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string

--- a/test/test_image_caption.py
+++ b/test/test_image_caption.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/test/test_image_caption.py
+++ b/test/test_image_caption.py
@@ -248,3 +248,15 @@ def test_combined_options():
         ],
     )
     assert out_string == expected_string
+
+
+def test_image_attr_list():
+    in_string = """\
+![alt text](/path/to/image.png "Title"){#testid .testal}"""
+    expected_string = """\
+<figure id="_figure-1">
+<img alt="alt text" class="testal" id="testid" src="/path/to/image.png" />
+<figcaption><span>Figure&nbsp;1:</span> Title</figcaption>
+</figure>"""
+    out_string = markdown.markdown(in_string, extensions=["attr_list", ImageCaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -20,3 +20,15 @@ Listing: Simple listing test"""
 </div>"""
     out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
     assert out_string == expected_string
+
+
+def test_listing_attr_list():
+    in_string = """\
+Listing: Simple listing test\n\
+{#testid .testclass}"""
+    expected_string = """\
+<div class="listing testclass" id="testid">
+<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
+</div>"""
+    out_string = markdown.markdown(in_string, extensions=["attr_list", CaptionExtension()])
+    assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -15,8 +15,8 @@ def test_listing():
     in_string = """\
 Listing: Simple listing test"""
     expected_string = """\
-<div class=listing id="_listing-1">
+<div class="listing" id="_listing-1">
 <figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
-</div class=listing>"""
+</div>"""
     out_string = markdown.markdown(in_string, extensions=[CaptionExtension()])
     assert out_string == expected_string

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/test/test_listing_caption.py
+++ b/test/test_listing_caption.py
@@ -32,3 +32,91 @@ Listing: Simple listing test\n\
 </div>"""
     out_string = markdown.markdown(in_string, extensions=["attr_list", CaptionExtension()])
     assert out_string == expected_string
+
+
+def test_listing_preserve_numbering():
+    in_string = """\
+Listing 123: Simple listing test"""
+    expected_string = """\
+<div class="listing" id="_listing-123">
+<figcaption><span>Listing&nbsp;123:</span> Simple listing test</figcaption>
+</div>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            CaptionExtension(
+                numbering_preserve=True,
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_listing_custom_match_re():
+    in_string = """\
+Abbildung 123: Simple listing test"""
+    expected_string = """\
+<div class="listing" id="_listing-1">
+<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
+</div>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            CaptionExtension(
+                caption_match_re=r"^(?:Listing|Abbildung)\s*?(?P<number>\d*)\:\s*(?P<title>.*)",
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_listing_skip_without_title():
+    in_string = """\
+Listing 123:"""
+    expected_string = """\
+<p>Listing 123:</p>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            CaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_listing_dont_skip_filled_title():
+    in_string = """\
+Listing: Simple listing test"""
+    expected_string = """\
+<div class="listing" id="_listing-1">
+<figcaption><span>Listing&nbsp;1:</span> Simple listing test</figcaption>
+</div>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            CaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_listing_attr_list_skip_without_title():
+    in_string = """\
+Listing: \n\
+{#testid .testclass}"""
+    expected_string = """\
+<p class="testclass" id="testid">Listing: </p>"""
+    out_string = markdown.markdown(
+        in_string,
+        extensions=[
+            "attr_list",
+            CaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2020-2023 flywire
 # Copyright (c) 2023 sanzoghenzo
+# Copyright (c) 2023 Hendrik Polczynski
 # forked from yafg - https://git.sr.ht/~ferruck/yafg
 # Copyright (c) 2019 Philipp Trommler
 #

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -64,6 +64,17 @@ TABLE_INNER_CONTENT = """<thead>
 </tbody>"""
 
 
+BASE_MD_TABLE_ATTR_LIST = """\
+Table: Example with heading, two columns and a row
+{#testid .testal}
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+"""
+
+
 def test_defaults():
     expected_string = """\
 <table id="_table-1">
@@ -131,4 +142,24 @@ def test_caption_prefix():
 {}
 </table>""".format(TABLE_INNER_CONTENT)
     out_string = markdown.markdown(BASE_MD_TABLE, extensions=["tables", TableCaptionExtension(caption_prefix="Tabula")])
+    assert out_string == expected_string
+
+
+def test_attr_list():
+    expected_string = """\
+<table class="testal" id="testid">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE_ATTR_LIST, extensions=["attr_list", "tables", TableCaptionExtension()])
+    assert out_string == expected_string
+
+
+def test_content_class_attr_list():
+    expected_string = """\
+<table class="testclass testal" id="testid">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(BASE_MD_TABLE_ATTR_LIST, extensions=["attr_list", "tables", TableCaptionExtension(content_class="testclass")])
     assert out_string == expected_string

--- a/test/test_table_caption.py
+++ b/test/test_table_caption.py
@@ -75,6 +75,16 @@ Table: Example with heading, two columns and a row
 """
 
 
+BASE_MD_TABLE_NO_TITLE = """\
+Table: 
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+"""
+
+
 def test_defaults():
     expected_string = """\
 <table id="_table-1">
@@ -162,4 +172,40 @@ def test_content_class_attr_list():
 {}
 </table>""".format(TABLE_INNER_CONTENT)
     out_string = markdown.markdown(BASE_MD_TABLE_ATTR_LIST, extensions=["attr_list", "tables", TableCaptionExtension(content_class="testclass")])
+    assert out_string == expected_string
+
+
+def test_skip_without_title():
+    expected_string = """\
+<p>Table: </p>
+<table>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(
+        BASE_MD_TABLE_NO_TITLE,
+        extensions=[
+            "tables",
+            TableCaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
+    assert out_string == expected_string
+
+
+def test_defaults_dont_skip_filled_title():
+    expected_string = """\
+<table id="_table-1">
+<caption><span>Table&nbsp;1:</span> Example with heading, two columns and a row</caption>
+{}
+</table>""".format(TABLE_INNER_CONTENT)
+    out_string = markdown.markdown(
+        BASE_MD_TABLE,
+        extensions=[
+            "tables",
+            TableCaptionExtension(
+                caption_skip_empty=True,
+            )
+        ],
+    )
     assert out_string == expected_string


### PR DESCRIPTION
Hi,

implemented new options:
- caption_match_re: for more flexible md caption text match (e.g. internationalization) (by default compatible to previous config)
- optionally skip empty captions (e.g. for markdown images that are just Icons without title)
- optionally preserve (optionally) matched numbers from the md match (e.g. to preserve fixed numbers in a document), if no number present fallback to auto-incremented numbers

refactor:
- reuse as much as possible of matching, title, number logic (listing caption class now almost empty)

Tests+Readme also updated

Is based on the first PR which fixed attr_lists.